### PR TITLE
Move socket to instance variable

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -18,7 +18,7 @@ class App extends Component {
 
   componentDidMount() {
     const socket = socketIOClient("http://localhost:4001");
-    this.setState({ socket });
+    this.socket = socket;
 
     const myName = prompt("Enter your name") || undefined;
     if (myName) {
@@ -36,13 +36,13 @@ class App extends Component {
     socket.on("judgment", judgment => this.setState({ judgment }));
   }
 
-  handleKick = name => this.state.socket.emit("kick", name);
-  handlePhase = phase => this.state.socket.emit("phase", phase);
-  submitClue = clue => this.state.socket.emit("clue", clue);
-  submitGuess = guess => this.state.socket.emit("guess", guess);
-  submitJudge = judgment => this.state.socket.emit("judge", judgment);
-  submitReveal = () => this.state.socket.emit("reveal");
-  toggleClue = name => this.state.socket.emit("toggle", name);
+  handleKick = name => this.socket.emit("kick", name);
+  handlePhase = phase => this.socket.emit("phase", phase);
+  submitClue = clue => this.socket.emit("clue", clue);
+  submitGuess = guess => this.socket.emit("guess", guess);
+  submitJudge = judgment => this.socket.emit("judge", judgment);
+  submitReveal = () => this.socket.emit("reveal");
+  toggleClue = name => this.socket.emit("toggle", name);
 
   render() {
     const amActive = this.state.myName === this.state.activePlayer;


### PR DESCRIPTION
Makes it work on Firefox. Not entirely sure why, but the socket does not
need to be in React state and I would say it's best practice for it not
to be, since it does not affect what's displayed and changes/updates to
it does not need to trigger a rerender. Some citations:
https://reactjs.org/docs/react-component.html#state
https://reactjs.org/docs/state-and-lifecycle.html#adding-lifecycle-methods-to-a-class
https://www.freecodecamp.org/news/where-do-i-belong-a-guide-to-saving-react-component-data-in-state-store-static-and-this-c49b335e2a00/