### PR TITLE
Use name from URL

### DIFF
--- a/client/src/Room.js
+++ b/client/src/Room.js
@@ -111,7 +111,8 @@ class Room extends Component {
     const socket = this.socket;
     socket.emit("join", roomName);
 
-    let myName = "";
+    // if the url has the user's name in `...?name=John...`, use it
+    let myName = new URLSearchParams(window.location.search).get("name") || "";
     if (
       this.props.location &&
       this.props.location.state &&


### PR DESCRIPTION
https://rocketcrab.com/game/justone

In Rocketcrab, the user's name is provided by the URL. This PR updates the game to use this name if it is available so the user doesn't have to re-enter their name.